### PR TITLE
fix(Sentry3 Vision Sensor): 更新视觉传感器算法选项及YOLO标签偏移

### DIFF
--- a/gp/Libraries/AI/Sentry3 Vision Sensor.ubl
+++ b/gp/Libraries/AI/Sentry3 Vision Sensor.ubl
@@ -1,15 +1,15 @@
 module 'Sentry3 Vision Sensor' Control
 author '作者 AITosee'
 version 0 5
-choices sentryVisionMenu ' Color ' ' Blob ' ' AprilTag ' ' Line ' ' Learning ' ' Face ' ' Yolo ' ' QrCode ' ' BarCode ' ' OCR ' ' HandPose ' ' LicensePlate ' 
-choices sentryVisionValueMenu ' Blob ' ' AprilTag ' ' Learning ' ' Face ' ' Yolo ' ' BarCode ' ' OCR ' ' HandPose ' ' LicensePlate ' 
+choices sentryVisionMenu ' Color ' ' Blob ' ' AprilTag ' ' Line ' ' Learning ' ' Face ' ' Objects ' ' QrCode ' ' BarCode ' ' OCR ' ' HandPose ' ' LicensePlate ' 
+choices sentryVisionValueMenu ' Blob ' ' AprilTag ' ' Learning ' ' Face ' ' Objects ' ' BarCode ' ' OCR ' ' HandPose ' ' LicensePlate ' 
 choices sentryOperaVisionMenu ' Learning ' ' Face ' 
 choices sentryVisionParamNumMenu ' Color ' ' Blob ' 
 choices sentryVisionStringMenu ' QrCode ' ' BarCode ' ' OCR ' ' LicensePlate ' 
 choices sentryObjInfoMenu 'x-coord' 'y-coord' width height label 
 choices sentryObjInfoQrMenu 'x-coord' 'y-coord' width height 
 choices sentryAprilTagModeMenu '16H5' '25H9' '36H11' Circle21H7 Standard41H12 
-choices sentryYoloClassMenu '1  person' '2  bicycle' '3  car' '4  motorcycle' '5  airplane' '6  bus' '7  train' '8  truck' '9  boat' '10 traffic light' '11 fire hydrant' '12 stop sign' '13 parking meter' '14 bench' '15 bird' '16 cat' '17 dog' '18 horse' '19 sheep' '20 cow' '21 elephant' '22 bear' '23 zebra' '24 giraffe' '25 backpack' '26 umbrella' '27 handbag' '28 tie' '29 suitcase' '30 frisbee' '31 skis' '32 snowboard' '33 sports ball' '34 kite' '35 baseball bat' '36 baseball glove' '37 skateboard' '38 surfboard' '39 tennis racket' '40 bottle' '41 wine glass' '42 cup' '43 fork' '44 knife' '45 spoon' '46 bowl' '47 banana' '48 apple' '49 sandwich' '50 orange' '51 broccoli' '52 carrot' '53 hot dog' '54 pizza' '55 donut' '56 cake' '57 chair' '58 couch' '59 potted plant' '60 bed' '61 dining table' '62 toilet' '63 tv' '64 laptop' '65 mouse' '66 remote' '67 keyboard' '68 cell phone' '69 microwave' '70 oven' '71 toaster' '72 sink' '73 refrigerator' '74 book' '75 clock' '76 vase' '77 scissors' '78 teddy bear' '79 hair drier' '80 toothbrush' 
+choices sentryObjectsClassMenu '1  person' '2  bicycle' '3  car' '4  motorcycle' '5  airplane' '6  bus' '7  train' '8  truck' '9  boat' '10 traffic light' '11 fire hydrant' '12 stop sign' '13 parking meter' '14 bench' '15 bird' '16 cat' '17 dog' '18 horse' '19 sheep' '20 cow' '21 elephant' '22 bear' '23 zebra' '24 giraffe' '25 backpack' '26 umbrella' '27 handbag' '28 tie' '29 suitcase' '30 frisbee' '31 skis' '32 snowboard' '33 sports ball' '34 kite' '35 baseball bat' '36 baseball glove' '37 skateboard' '38 surfboard' '39 tennis racket' '40 bottle' '41 wine glass' '42 cup' '43 fork' '44 knife' '45 spoon' '46 bowl' '47 banana' '48 apple' '49 sandwich' '50 orange' '51 broccoli' '52 carrot' '53 hot dog' '54 pizza' '55 donut' '56 cake' '57 chair' '58 couch' '59 potted plant' '60 bed' '61 dining table' '62 toilet' '63 tv' '64 laptop' '65 mouse' '66 remote' '67 keyboard' '68 cell phone' '69 microwave' '70 oven' '71 toaster' '72 sink' '73 refrigerator' '74 book' '75 clock' '76 vase' '77 scissors' '78 teddy bear' '79 hair drier' '80 toothbrush' 
 choices sentryObjInfoColorMenu label 'red CH value' 'green CH value' 'blue CH value' 
 choices sentryColorMenu Black White Red Green Blue Yellow 
 choices sentryVisionStaMenu run stop 
@@ -23,7 +23,7 @@ choices sentryBarcodeModeMenu All ENA13 Code128 Code39
 choices sentryAddrMenu '0x60' '0x61' '0x62' '0x63' 
 choices sentryLedColorMenu Black Red Green Yellow Blue Purple Cyan White 
 description 'Sentry3 vision sensor library with I2C/UART support
-Supports color detection, blob detection, AprilTag, line detection, learning mode, qr，ocr, face detection, and yolo object detection
+Supports color detection, blob detection, AprilTag, line detection, learning mode, qr，ocr, face detection, and Objects object detection
 '
 variables _sentry_index _sentry_vision_list _sentry_obj_info_list _sentry_config_list _sentry_cache_validation _sentry_uart_packet_buffer _sentry_uart_response_buffer _sentry_buffer_size _sentry_params_buffer _sentry_cache_entry _sentry_err _sentry_vision_id _sentry_index_val 
 
@@ -33,11 +33,7 @@ variables _sentry_index _sentry_vision_list _sentry_obj_info_list _sentry_config
   spec ' ' 'Sentry3 VisionSetParamNum' 'Set  Sentry3 _  algo _  _ sets of params' 'menu.sentryIndexMenu menu.sentryVisionParamNumMenu num' '#1' ' Color ' 1
   spec ' ' 'Sentry3 VisionColorSetParam' 'Set  Sentry3 _  algo Color  x-coord _ y-coord _ width _ height _ paramset _' 'menu.sentryIndexMenu num num num num num' '#1' 50 50 3 4 1
   spec ' ' 'Sentry3 VisionBlobSetParam' 'Set  Sentry3 _  algo Blob  min-width _ min-height _ color _ paramset _' 'menu.sentryIndexMenu num num menu.sentryColorMenu num' '#1' 3 4 'Red' 1
-  spec ' ' 'Sentry3 VisionSetBlobNum' 'Set  Sentry3 _  algo Blob  max num of blobs for each color(1-5) _' 'menu.sentryIndexMenu num' '#1' 1
-  spec ' ' 'Sentry3 VisionSetAprilTagMode' 'Set  Sentry3 _  algo AprilTag  format _' 'menu.sentryIndexMenu menu.sentryAprilTagModeMenu' '#1' '36H11'
-  spec ' ' 'Sentry3 VisionSetLineNum' 'Set  Sentry3 _  algo Line  max num of lines(1-5) _' 'menu.sentryIndexMenu num' '#1' 1
   spec ' ' 'Sentry3 VisionSetParam' 'Set  Sentry3 _  algo _  _  ID _' 'menu.sentryIndexMenu menu.sentryOperaVisionMenu menu.sentryOperaParamMenu num' '#1' ' Learning ' 'learn and assign' 1
-  spec ' ' 'Sentry3 VisionSetBarCodeMode' 'Set  Sentry3 _  algo BarCode  format _' 'menu.sentryIndexMenu menu.sentryBarcodeModeMenu' '#1' 'All'
   spec 'r' 'Sentry3 VisionDetectedCount' 'Sentry3 _  algo _  num of results' 'menu.sentryIndexMenu menu.sentryVisionMenu' '#1' ' Color '
   spec 'r' 'Sentry3 GetVisionObjColorValue' 'Sentry3 _  algo Color  _ of result _' 'menu.sentryIndexMenu menu.sentryObjInfoColorMenu num' '#1' 'label' 1
   spec 'r' 'Sentry3 GetVisionObjValue' 'Sentry3 _  algo _  _ of result _' 'menu.sentryIndexMenu menu.sentryVisionValueMenu menu.sentryObjInfoMenu num' '#1' ' Blob ' 'x-coord' 1
@@ -46,7 +42,7 @@ variables _sentry_index _sentry_vision_list _sentry_obj_info_list _sentry_config
   spec 'r' 'Sentry3 GetString' 'Sentry3 _  algo _  string of decoding result _' 'menu.sentryIndexMenu menu.sentryVisionStringMenu num' '#1' ' QrCode ' 1
   spec 'r' 'Sentry3 VisionDetectedColor' 'Sentry3 _  algo Color  recognized _ result _' 'menu.sentryIndexMenu menu.sentryColorMenu num' '#1' 'Black' 1
   spec 'r' 'Sentry3 VisionDetectedBlob' 'Sentry3 _  algo Blob  detected _ blob result _' 'menu.sentryIndexMenu menu.sentryColorMenu num' '#1' 'Red' 1
-  spec 'r' 'Sentry3 VisionDetectedYolo' 'Sentry3 _  algo Yolo  recognized _ result _' 'menu.sentryIndexMenu menu.sentryYoloClassMenu num' '#1' '1  person' 1
+  spec 'r' 'Sentry3 VisionDetectedObjects' 'Sentry3 _  algo Objects  recognized _ result _' 'menu.sentryIndexMenu menu.sentryObjectsClassMenu num' '#1' '1  person' 1
   spec 'r' 'Sentry3 VisionDetectedHandPoseCustom' 'Sentry3 _  algo HandPose  detected custom gesture  thumb _ index _ middle _ ring _ pinky _ result _' 'menu.sentryIndexMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu num' '#1' 'extended' 'extended' 'extended' 'extended' 'extended' 1
   spec 'r' 'Sentry3 VisionDetectedHandPosePreset' 'Sentry3 _  algo HandPose  detected preset gesture _ result _' 'menu.sentryIndexMenu menu.sentryHandPosePresetMenu num' '#1' 'One' 1
 
@@ -334,21 +330,21 @@ to 'Sentry3 VisionDetectedHandPosePreset' index_menu handpose_preset obj_id {
   return ((label & 31) == ('_sentry_get_handpose_preset_value' handpose_preset))
 }
 
-to 'Sentry3 VisionDetectedYolo' index_menu yolo_class obj_id {
-  comment 'Check if Yolo vision detected specific class'
+to 'Sentry3 VisionDetectedObjects' index_menu Objects_class obj_id {
+  comment 'Check if Objects vision detected specific class'
   _sentry_index = ('_sentry get index from menu' index_menu)
   if (_sentry_index == 0) {
     return false
   }
-  comment 'Get yolo class index by extracting number from prefix (format: "N  label" or "NN label")'
+  comment 'Get Objects class index by extracting number from prefix (format: "N  label" or "NN label")'
   comment 'Find first space position'
-  local 'spacePos' ('[data:find]' ' ' yolo_class)
+  local 'spacePos' ('[data:find]' ' ' Objects_class)
   if (spacePos == 0) {
     comment 'No space found, invalid format'
     return 0
   }
   comment 'Extract number part (from start to before first space) and convert to number'
-  return (('_sentry getValue' _sentry_index ' Yolo ' 'label' obj_id) == (('[data:convertType]' ('[data:copyFromTo]' yolo_class 1 (spacePos - 1)) 'number')))
+  return (('_sentry getValue' _sentry_index ' Objects ' 'label' obj_id) == (('[data:convertType]' ('[data:copyFromTo]' Objects_class 1 (spacePos - 1)) 'number')))
 }
 
 to 'Sentry3 VisionSetAprilTagMode' index_menu apriltag_mode {
@@ -679,7 +675,7 @@ to '_sentry initialize base' index {
 
 to '_sentry initialize label lists' {
   comment 'Initialize label lists for better property mapping'
-  _sentry_vision_list = ('[data:makeList]' ' Color ' ' Blob ' ' AprilTag ' ' Line ' ' Learning ' 'n' ' Face ' ' Yolo ' ' QrCode ' ' BarCode ' 'n' ' OCR ' ' HandPose ' ' LicensePlate ')
+  _sentry_vision_list = ('[data:makeList]' ' Color ' ' Blob ' ' AprilTag ' ' Line ' ' Learning ' 'n' ' Face ' ' Objects ' ' QrCode ' ' BarCode ' 'n' ' OCR ' ' HandPose ' ' LicensePlate ')
   local 'obj_info_group1' ('[data:makeList]' 'status' 'x-coord' 'y-coord' 'width' 'height')
   local 'obj_info_group2' ('[data:makeList]' 'label' 'red CH value' 'green CH value' 'blue CH value')
   local 'obj_info_group3' ('[data:makeList]' 'x-coord of ending point' 'y-coord of ending point' 'x-coord of starting point' 'y-coord of starting point' 'inclination angle')

--- a/gp/Libraries/AI/Sentry3 Vision Sensor.ubl
+++ b/gp/Libraries/AI/Sentry3 Vision Sensor.ubl
@@ -43,8 +43,8 @@ variables _sentry_index _sentry_vision_list _sentry_obj_info_list _sentry_config
   spec 'r' 'Sentry3 VisionDetectedColor' 'Sentry3 _  algo Color  recognized _ result _' 'menu.sentryIndexMenu menu.sentryColorMenu num' '#1' 'Black' 1
   spec 'r' 'Sentry3 VisionDetectedBlob' 'Sentry3 _  algo Blob  detected _ blob result _' 'menu.sentryIndexMenu menu.sentryColorMenu num' '#1' 'Red' 1
   spec 'r' 'Sentry3 VisionDetectedObjects' 'Sentry3 _  algo Objects  recognized _ result _' 'menu.sentryIndexMenu menu.sentryObjectsClassMenu num' '#1' '1  person' 1
-  spec 'r' 'Sentry3 VisionDetectedHandPoseCustom' 'Sentry3 _  algo HandPose  detected custom gesture  thumb _ index _ middle _ ring _ pinky _ result _' 'menu.sentryIndexMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu num' '#1' 'extended' 'extended' 'extended' 'extended' 'extended' 1
-  spec 'r' 'Sentry3 VisionDetectedHandPosePreset' 'Sentry3 _  algo HandPose  detected preset gesture _ result _' 'menu.sentryIndexMenu menu.sentryHandPosePresetMenu num' '#1' 'One' 1
+  spec 'r' 'Sentry3 VisionDetectedHandPoseCustom' 'Sentry3 _  algo HandPose  recognized custom gesture  thumb _ index _ middle _ ring _ pinky _ result _' 'menu.sentryIndexMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu num' '#1' 'extended' 'extended' 'extended' 'extended' 'extended' 1
+  spec 'r' 'Sentry3 VisionDetectedHandPosePreset' 'Sentry3 _  algo HandPose  recognized preset gesture _ result _' 'menu.sentryIndexMenu menu.sentryHandPosePresetMenu num' '#1' 'One' 1
 
 to 'Sentry3 Begin' index_menu comm_mode address {
   comment 'Initialize SentryBase with index, communication mode and I2C address'

--- a/gp/Libraries/AI/Sentry3 Vision Sensor.ubl
+++ b/gp/Libraries/AI/Sentry3 Vision Sensor.ubl
@@ -15,7 +15,7 @@ choices sentryColorMenu Black White Red Green Blue Yellow
 choices sentryVisionStaMenu run stop 
 choices sentryIndexMenu '#1' '#2' '#3' '#4' '#5' 
 choices sentryHandPoseFingerStateMenu bent extended ignore 
-choices sentryHandPosePresetMenu One Two Three Four Five Six Eight Ten yeah Rock Scissors Paper Like OK 
+choices sentryHandPosePresetMenu One Two Three Four Five Six Eight Ten Yeah Rock Scissors Paper Like OK 
 choices sentryObjInfoLineMenu 'x-coord of ending point' 'y-coord of ending point' 'x-coord of starting point' 'y-coord of starting point' 'inclination angle' 
 choices sentryCommModeMenu I2C Serial 
 choices sentryOperaParamMenu 'learn and assign' 'delete data' 
@@ -46,7 +46,7 @@ variables _sentry_index _sentry_vision_list _sentry_obj_info_list _sentry_config
   spec 'r' 'Sentry3 GetString' 'Sentry3 _  algo _  string of decoding result _' 'menu.sentryIndexMenu menu.sentryVisionStringMenu num' '#1' ' QrCode ' 1
   spec 'r' 'Sentry3 VisionDetectedColor' 'Sentry3 _  algo Color  recognized _ result _' 'menu.sentryIndexMenu menu.sentryColorMenu num' '#1' 'Black' 1
   spec 'r' 'Sentry3 VisionDetectedBlob' 'Sentry3 _  algo Blob  detected _ blob result _' 'menu.sentryIndexMenu menu.sentryColorMenu num' '#1' 'Red' 1
-  spec 'r' 'Sentry3 VisionDetectedYolo' 'Sentry3 _  algo Yolo  recognized _ result _' 'menu.sentryIndexMenu menu.sentryYoloClassMenu num' '#1' '0  person' 1
+  spec 'r' 'Sentry3 VisionDetectedYolo' 'Sentry3 _  algo Yolo  recognized _ result _' 'menu.sentryIndexMenu menu.sentryYoloClassMenu num' '#1' '1  person' 1
   spec 'r' 'Sentry3 VisionDetectedHandPoseCustom' 'Sentry3 _  algo HandPose  detected custom gesture  thumb _ index _ middle _ ring _ pinky _ result _' 'menu.sentryIndexMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu num' '#1' 'extended' 'extended' 'extended' 'extended' 'extended' 1
   spec 'r' 'Sentry3 VisionDetectedHandPosePreset' 'Sentry3 _  algo HandPose  detected preset gesture _ result _' 'menu.sentryIndexMenu menu.sentryHandPosePresetMenu num' '#1' 'One' 1
 
@@ -984,7 +984,7 @@ to '_sentry_get_handpose_preset_value' handpose_preset {
   comment 'Return preset value directly based on preset name'
   if (handpose_preset == 'One') {
     return 2
-  } (or (handpose_preset == 'Two') (handpose_preset == 'yeah')) {
+  } (or (handpose_preset == 'Two') (handpose_preset == 'Yeah')) {
     return 6
   } (or (handpose_preset == 'Three') (handpose_preset == 'OK')) {
     return 28

--- a/gp/Libraries/AI/Sentry3 Vision Sensor.ubl
+++ b/gp/Libraries/AI/Sentry3 Vision Sensor.ubl
@@ -1,15 +1,15 @@
 module 'Sentry3 Vision Sensor' Control
 author '作者 AITosee'
-version 0 4
-choices sentryVisionMenu ' Color ' ' Blob ' ' AprilTag ' ' Line ' ' Learning ' ' Face ' ' Yolo ' ' QrCode ' ' BarCode ' ' OCR ' ' HandGesture ' ' LicensePlate ' 
-choices sentryVisionValueMenu ' Blob ' ' AprilTag ' ' Learning ' ' Face ' ' Yolo ' ' BarCode ' ' OCR ' ' HandGesture ' ' LicensePlate ' 
+version 0 5
+choices sentryVisionMenu ' Color ' ' Blob ' ' AprilTag ' ' Line ' ' Learning ' ' Face ' ' Yolo ' ' QrCode ' ' BarCode ' ' OCR ' ' HandPose ' ' LicensePlate ' 
+choices sentryVisionValueMenu ' Blob ' ' AprilTag ' ' Learning ' ' Face ' ' Yolo ' ' BarCode ' ' OCR ' ' HandPose ' ' LicensePlate ' 
 choices sentryOperaVisionMenu ' Learning ' ' Face ' 
 choices sentryVisionParamNumMenu ' Color ' ' Blob ' 
 choices sentryVisionStringMenu ' QrCode ' ' BarCode ' ' OCR ' ' LicensePlate ' 
 choices sentryObjInfoMenu 'x-coord' 'y-coord' width height label 
 choices sentryObjInfoQrMenu 'x-coord' 'y-coord' width height 
 choices sentryAprilTagModeMenu '16H5' '25H9' '36H11' Circle21H7 Standard41H12 
-choices sentryYoloClassMenu '0  person' '1  bicycle' '2  car' '3  motorcycle' '4  airplane' '5  bus' '6  train' '7  truck' '8  boat' '9  traffic light' '10 fire hydrant' '11 stop sign' '12 parking meter' '13 bench' '14 bird' '15 cat' '16 dog' '17 horse' '18 sheep' '19 cow' '20 elephant' '21 bear' '22 zebra' '23 giraffe' '24 backpack' '25 umbrella' '26 handbag' '27 tie' '28 suitcase' '29 frisbee' '30 skis' '31 snowboard' '32 sports ball' '33 kite' '34 baseball bat' '35 baseball glove' '36 skateboard' '37 surfboard' '38 tennis racket' '39 bottle' '40 wine glass' '41 cup' '42 fork' '43 knife' '44 spoon' '45 bowl' '46 banana' '47 apple' '48 sandwich' '49 orange' '50 broccoli' '51 carrot' '52 hot dog' '53 pizza' '54 donut' '55 cake' '56 chair' '57 couch' '58 potted plant' '59 bed' '60 dining table' '61 toilet' '62 tv' '63 laptop' '64 mouse' '65 remote' '66 keyboard' '67 cell phone' '68 microwave' '69 oven' '70 toaster' '71 sink' '72 refrigerator' '73 book' '74 clock' '75 vase' '76 scissors' '77 teddy bear' '78 hair drier' '79 toothbrush' 
+choices sentryYoloClassMenu '1  person' '2  bicycle' '3  car' '4  motorcycle' '5  airplane' '6  bus' '7  train' '8  truck' '9  boat' '10 traffic light' '11 fire hydrant' '12 stop sign' '13 parking meter' '14 bench' '15 bird' '16 cat' '17 dog' '18 horse' '19 sheep' '20 cow' '21 elephant' '22 bear' '23 zebra' '24 giraffe' '25 backpack' '26 umbrella' '27 handbag' '28 tie' '29 suitcase' '30 frisbee' '31 skis' '32 snowboard' '33 sports ball' '34 kite' '35 baseball bat' '36 baseball glove' '37 skateboard' '38 surfboard' '39 tennis racket' '40 bottle' '41 wine glass' '42 cup' '43 fork' '44 knife' '45 spoon' '46 bowl' '47 banana' '48 apple' '49 sandwich' '50 orange' '51 broccoli' '52 carrot' '53 hot dog' '54 pizza' '55 donut' '56 cake' '57 chair' '58 couch' '59 potted plant' '60 bed' '61 dining table' '62 toilet' '63 tv' '64 laptop' '65 mouse' '66 remote' '67 keyboard' '68 cell phone' '69 microwave' '70 oven' '71 toaster' '72 sink' '73 refrigerator' '74 book' '75 clock' '76 vase' '77 scissors' '78 teddy bear' '79 hair drier' '80 toothbrush' 
 choices sentryObjInfoColorMenu label 'red CH value' 'green CH value' 'blue CH value' 
 choices sentryColorMenu Black White Red Green Blue Yellow 
 choices sentryVisionStaMenu run stop 
@@ -27,7 +27,7 @@ Supports color detection, blob detection, AprilTag, line detection, learning mod
 '
 variables _sentry_index _sentry_vision_list _sentry_obj_info_list _sentry_config_list _sentry_cache_validation _sentry_uart_packet_buffer _sentry_uart_response_buffer _sentry_buffer_size _sentry_params_buffer _sentry_cache_entry _sentry_err _sentry_vision_id _sentry_index_val 
 
-  spec ' ' 'Sentry3 Begin' 'Initialize    Sentry3 _  port _ addr _' 'menu.sentryIndexMenu menu.sentryCommModeMenu menu.sentryAddrMenu' '#1' 'I2C' '0x60'
+  spec ' ' 'Sentry3 Begin' 'Initialize  Sentry3 _  port _ addr _' 'menu.sentryIndexMenu menu.sentryCommModeMenu menu.sentryAddrMenu' '#1' 'I2C' '0x60'
   spec ' ' 'Sentry3 LedSetColor' 'Set  Sentry3 _  light color _ when targets were detected otherwise _ luma(1-15) _' 'menu.sentryIndexMenu menu.sentryLedColorMenu menu.sentryLedColorMenu num' '#1' 'Red' 'Blue' 1
   spec ' ' 'Sentry3 VisionSetStatus' 'Set  Sentry3 _  _  algo _' 'menu.sentryIndexMenu menu.sentryVisionStaMenu menu.sentryVisionMenu' '#1' 'run' ' Color '
   spec ' ' 'Sentry3 VisionSetParamNum' 'Set  Sentry3 _  algo _  _ sets of params' 'menu.sentryIndexMenu menu.sentryVisionParamNumMenu num' '#1' ' Color ' 1
@@ -47,8 +47,8 @@ variables _sentry_index _sentry_vision_list _sentry_obj_info_list _sentry_config
   spec 'r' 'Sentry3 VisionDetectedColor' 'Sentry3 _  algo Color  recognized _ result _' 'menu.sentryIndexMenu menu.sentryColorMenu num' '#1' 'Black' 1
   spec 'r' 'Sentry3 VisionDetectedBlob' 'Sentry3 _  algo Blob  detected _ blob result _' 'menu.sentryIndexMenu menu.sentryColorMenu num' '#1' 'Red' 1
   spec 'r' 'Sentry3 VisionDetectedYolo' 'Sentry3 _  algo Yolo  recognized _ result _' 'menu.sentryIndexMenu menu.sentryYoloClassMenu num' '#1' '0  person' 1
-  spec 'r' 'Sentry3 VisionDetectedHandPoseCustom' 'Sentry3 _  algo HandGesture  detected custom handpose  thumb _ index _ middle _ ring _ pinky _ result _' 'menu.sentryIndexMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu num' '#1' 'extended' 'extended' 'extended' 'extended' 'extended' 1
-  spec 'r' 'Sentry3 VisionDetectedHandPosePreset' 'Sentry3 _  algo HandGesture  detected preset handpose _ result _' 'menu.sentryIndexMenu menu.sentryHandPosePresetMenu num' '#1' 'One' 1
+  spec 'r' 'Sentry3 VisionDetectedHandPoseCustom' 'Sentry3 _  algo HandPose  detected custom gesture  thumb _ index _ middle _ ring _ pinky _ result _' 'menu.sentryIndexMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu menu.sentryHandPoseFingerStateMenu num' '#1' 'extended' 'extended' 'extended' 'extended' 'extended' 1
+  spec 'r' 'Sentry3 VisionDetectedHandPosePreset' 'Sentry3 _  algo HandPose  detected preset gesture _ result _' 'menu.sentryIndexMenu menu.sentryHandPosePresetMenu num' '#1' 'One' 1
 
 to 'Sentry3 Begin' index_menu comm_mode address {
   comment 'Initialize SentryBase with index, communication mode and I2C address'
@@ -116,7 +116,7 @@ to 'Sentry3 GetVisionObjLineValue' index_menu obj_info obj_id {
   if (_sentry_index == 0) {
     return 0
   }
-  return ('_sentry getValue' _sentry_index 'Line' obj_info obj_id)
+  return ('_sentry getValue' _sentry_index ' Line ' obj_info obj_id)
 }
 
 to 'Sentry3 GetVisionObjStringValue' index_menu vision_type obj_info obj_id {
@@ -271,15 +271,15 @@ to 'Sentry3 VisionDetectedCount' index_menu vision_type {
 }
 
 to 'Sentry3 VisionDetectedHandPoseCustom' index_menu thumb_state index_state middle_state ring_state pinky_state obj_id {
-  comment 'Check if HandGesture vision detected custom handpose'
+  comment 'Check if HandPose vision detected custom handpose'
   comment 'Finger states: bent(0), extended(1), ignore(-1)'
   comment 'Bit order: bit4(pinky) bit3(ring) bit2(middle) bit1(index) bit0(thumb)'
   _sentry_index = ('_sentry get index from menu' index_menu)
   if (_sentry_index == 0) {
     return false
   }
-  comment 'Get label value from HandGesture result'
-  local 'label' ('_sentry getValue' _sentry_index 'HandGesture' 'label' obj_id)
+  comment 'Get label value from HandPose result'
+  local 'label' ('_sentry getValue' _sentry_index ' HandPose ' 'label' obj_id)
   comment 'Calculate mask and status based on finger states'
   local 'mask' 0
   local 'status' 0
@@ -323,13 +323,13 @@ to 'Sentry3 VisionDetectedHandPoseCustom' index_menu thumb_state index_state mid
 }
 
 to 'Sentry3 VisionDetectedHandPosePreset' index_menu handpose_preset obj_id {
-  comment 'Check if HandGesture vision detected preset handpose'
+  comment 'Check if HandPose vision detected preset handpose'
   _sentry_index = ('_sentry get index from menu' index_menu)
   if (_sentry_index == 0) {
     return false
   }
-  comment 'Get label value from HandGesture result'
-  local 'label' ('_sentry getValue' _sentry_index 'HandGesture' 'label' obj_id)
+  comment 'Get label value from HandPose result'
+  local 'label' ('_sentry getValue' _sentry_index ' HandPose ' 'label' obj_id)
   comment 'Check if (label & 0b11111) == preset_value'
   return ((label & 31) == ('_sentry_get_handpose_preset_value' handpose_preset))
 }
@@ -348,7 +348,7 @@ to 'Sentry3 VisionDetectedYolo' index_menu yolo_class obj_id {
     return 0
   }
   comment 'Extract number part (from start to before first space) and convert to number'
-  return (('_sentry getValue' _sentry_index 'Yolo' 'label' obj_id) == (('[data:convertType]' ('[data:copyFromTo]' yolo_class 1 (spacePos - 1)) 'number')))
+  return (('_sentry getValue' _sentry_index ' Yolo ' 'label' obj_id) == (('[data:convertType]' ('[data:copyFromTo]' yolo_class 1 (spacePos - 1)) 'number')))
 }
 
 to 'Sentry3 VisionSetAprilTagMode' index_menu apriltag_mode {
@@ -679,7 +679,7 @@ to '_sentry initialize base' index {
 
 to '_sentry initialize label lists' {
   comment 'Initialize label lists for better property mapping'
-  _sentry_vision_list = ('[data:makeList]' ' Color ' ' Blob ' 'AprilTag' 'Line' ' Learning ' 'n' 'Face' 'Yolo' ' QrCode ' 'BarCode' 'n' 'OCR' 'HandGesture' 'LicensePlate')
+  _sentry_vision_list = ('[data:makeList]' ' Color ' ' Blob ' ' AprilTag ' ' Line ' ' Learning ' 'n' ' Face ' ' Yolo ' ' QrCode ' ' BarCode ' 'n' ' OCR ' ' HandPose ' ' LicensePlate ')
   local 'obj_info_group1' ('[data:makeList]' 'status' 'x-coord' 'y-coord' 'width' 'height')
   local 'obj_info_group2' ('[data:makeList]' 'label' 'red CH value' 'green CH value' 'blue CH value')
   local 'obj_info_group3' ('[data:makeList]' 'x-coord of ending point' 'y-coord of ending point' 'x-coord of starting point' 'y-coord of starting point' 'inclination angle')

--- a/translations/zh-chs.po
+++ b/translations/zh-chs.po
@@ -5108,7 +5108,7 @@ msgid "Sentry3 _  algo Blob  detected _ blob result _"
 msgstr "Sentry3 _  色块检测  检测到 _ 块 结果 _"
 
 #. Tip Bar text for a block in Sentry3 Vision Sensor library
-msgid "Sentry3 _  algo Yolo  recognized _ result _"
+msgid "Sentry3 _  algo Objects  recognized _ result _"
 msgstr "Sentry3 _  物体识别  识别到 _ 结果 _"
 
 #. Tip Bar text for a block in Sentry3 Vision Sensor library
@@ -5148,7 +5148,7 @@ msgid " Face "
 msgstr "人脸识别"
 
 #. Sentry3  Vision Sensor menu choices
-msgid " Yolo "
+msgid " Objects "
 msgstr "物体识别"
 
 #. Sentry3  Vision Sensor menu choices
@@ -5295,323 +5295,323 @@ msgstr "删除数据"
 msgid "All"
 msgstr "全部"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "1  person"
 msgstr "1  人"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "2  bicycle"
 msgstr "2  自行车"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "3  car"
 msgstr "3  汽车"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "4  motorcycle"
 msgstr "4  摩托车"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "5  airplane"
 msgstr "5  飞机"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "6  bus"
 msgstr "6  公交车"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "7  train"
 msgstr "7  火车"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "8  truck"
 msgstr "8  卡车"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "9  boat"
 msgstr "9  船"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "10 traffic light"
 msgstr "10 信号灯"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "11 fire hydrant"
 msgstr "11 消防栓"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "12 stop sign"
 msgstr "12 停车标志"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "13 parking meter"
 msgstr "13 计费器"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "14 bench"
 msgstr "14 长椅"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "15 bird"
 msgstr "15 鸟"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "16 cat"
 msgstr "16 猫"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "17 dog"
 msgstr "17 狗"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "18 horse"
 msgstr "18 马"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "19 sheep"
 msgstr "19 羊"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "20 cow"
 msgstr "20 牛"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "21 elephant"
 msgstr "21 大象"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "22 bear"
 msgstr "22 熊"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "23 zebra"
 msgstr "23 斑马"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "24 giraffe"
 msgstr "24 长颈鹿"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "25 backpack"
 msgstr "25 背包"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "26 umbrella"
 msgstr "26 雨伞"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "27 handbag"
 msgstr "27 手提包"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "28 tie"
 msgstr "28 领带"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "29 suitcase"
 msgstr "29 行李箱"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "30 frisbee"
 msgstr "30 飞盘"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "31 skis"
 msgstr "31 双滑雪板"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "32 snowboard"
 msgstr "32 单滑雪板"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "33 sports ball"
 msgstr "33 运动球类"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "34 kite"
 msgstr "34 风筝"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "35 baseball bat"
 msgstr "35 棒球棒"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "36 baseball glove"
 msgstr "36 棒球手套"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "37 skateboard"
 msgstr "37 滑板"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "38 surfboard"
 msgstr "38 冲浪板"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "39 tennis racket"
 msgstr "39 网球拍"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "40 bottle"
 msgstr "40 瓶子"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "41 wine glass"
 msgstr "41 红酒杯"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "42 cup"
 msgstr "42 杯子"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "43 fork"
 msgstr "43 叉子"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "44 knife"
 msgstr "44 刀"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "45 spoon"
 msgstr "45 勺子"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "46 bowl"
 msgstr "46 碗"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "47 banana"
 msgstr "47 香蕉"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "48 apple"
 msgstr "48 苹果"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "49 sandwich"
 msgstr "49 三明治"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "50 orange"
 msgstr "50 橙子"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "51 broccoli"
 msgstr "51 西兰花"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "52 carrot"
 msgstr "52 胡萝卜"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "53 hot dog"
 msgstr "53 热狗"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "54 pizza"
 msgstr "54 披萨"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "55 donut"
 msgstr "55 甜甜圈"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "56 cake"
 msgstr "56 蛋糕"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "57 chair"
 msgstr "57 椅子"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "58 couch"
 msgstr "58 沙发"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "59 potted plant"
 msgstr "59 盆栽植物"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "60 bed"
 msgstr "60 床"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "61 dining table"
 msgstr "61 餐桌"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "62 toilet"
 msgstr "62 马桶"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "63 tv"
 msgstr "63 显示器"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "64 laptop"
 msgstr "64 便携电脑"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "65 mouse"
 msgstr "65 鼠标"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "66 remote"
 msgstr "66 遥控器"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "67 keyboard"
 msgstr "67 键盘"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "68 cell phone"
 msgstr "68 手机"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "69 microwave"
 msgstr "69 微波炉"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "70 oven"
 msgstr "70 烤箱"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "71 toaster"
 msgstr "71 烤面包机"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "72 sink"
 msgstr "72 水槽"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "73 refrigerator"
 msgstr "73 冰箱"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "74 book"
 msgstr "74 书"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "75 clock"
 msgstr "75 钟表"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "76 vase"
 msgstr "76 花瓶"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "77 scissors"
 msgstr "77 剪刀"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "78 teddy bear"
 msgstr "78 泰迪熊"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "79 hair drier"
 msgstr "79 吹风机"
 
-#. Sentry 3 YOLO object classes
+#. Sentry 3 Objects object classes
 msgid "80 toothbrush"
 msgstr "80 牙刷"
 

--- a/translations/zh-chs.po
+++ b/translations/zh-chs.po
@@ -5112,16 +5112,12 @@ msgid "Sentry3 _  algo Objects  recognized _ result _"
 msgstr "Sentry3 _  物体识别  识别到 _ 结果 _"
 
 #. Tip Bar text for a block in Sentry3 Vision Sensor library
-msgid "Sentry3 _  algo HandPose  detected custom gesture  thumb _ index _ middle _ ring _ pinky _ result _"
+msgid "Sentry3 _  algo HandPose  recognized custom gesture  thumb _ index _ middle _ ring _ pinky _ result _"
 msgstr "Sentry3 _  手势姿态  识别到 大拇指 _ 食指 _ 中指 _ 无名指 _ 小拇指 _ 结果 _"
 
 #. Tip Bar text for a block in Sentry3 Vision Sensor library
-msgid "Sentry3 _  algo HandPose  detected preset gesture _ result _"
+msgid "Sentry3 _  algo HandPose  recognized preset gesture _ result _"
 msgstr "Sentry3 _  手势姿态  识别到 _ 结果 _"
-
-#. Tip Bar text for a block in Sentry3 Vision Sensor library
-msgid "Sentry3 _  algo LicensePlate  recognized _ result _"
-msgstr "Sentry3 _  车牌识别  识别到 _ 结果 _"
 
 #. Sentry3  Vision Sensor menu choices
 msgid " Color "

--- a/translations/zh-chs.po
+++ b/translations/zh-chs.po
@@ -5112,11 +5112,11 @@ msgid "Sentry3 _  algo Yolo  recognized _ result _"
 msgstr "Sentry3 _  物体识别  识别到 _ 结果 _"
 
 #. Tip Bar text for a block in Sentry3 Vision Sensor library
-msgid "Sentry3 _  algo HandGesture  detected custom handpose  thumb _ index _ middle _ ring _ pinky _ result _"
+msgid "Sentry3 _  algo HandPose  detected custom gesture  thumb _ index _ middle _ ring _ pinky _ result _"
 msgstr "Sentry3 _  手势姿态  识别到 大拇指 _ 食指 _ 中指 _ 无名指 _ 小拇指 _ 结果 _"
 
 #. Tip Bar text for a block in Sentry3 Vision Sensor library
-msgid "Sentry3 _  algo HandGesture  detected preset handpose _ result _"
+msgid "Sentry3 _  algo HandPose  detected preset gesture _ result _"
 msgstr "Sentry3 _  手势姿态  识别到 _ 结果 _"
 
 #. Tip Bar text for a block in Sentry3 Vision Sensor library
@@ -5168,7 +5168,7 @@ msgid " LicensePlate "
 msgstr "车牌识别"
 
 #. Sentry3  Vision Sensor menu choices
-msgid " HandGesture "
+msgid " HandPose "
 msgstr "手势姿态"
 
 #. Sentry3  Vision Sensor menu choices
@@ -5296,324 +5296,324 @@ msgid "All"
 msgstr "全部"
 
 #. Sentry 3 YOLO object classes
-msgid "0  person"
-msgstr "0  人"
+msgid "1  person"
+msgstr "1  人"
 
 #. Sentry 3 YOLO object classes
-msgid "1  bicycle"
-msgstr "1  自行车"
+msgid "2  bicycle"
+msgstr "2  自行车"
 
 #. Sentry 3 YOLO object classes
-msgid "2  car"
-msgstr "2  汽车"
+msgid "3  car"
+msgstr "3  汽车"
 
 #. Sentry 3 YOLO object classes
-msgid "3  motorcycle"
-msgstr "3  摩托车"
+msgid "4  motorcycle"
+msgstr "4  摩托车"
 
 #. Sentry 3 YOLO object classes
-msgid "4  airplane"
-msgstr "4  飞机"
+msgid "5  airplane"
+msgstr "5  飞机"
 
 #. Sentry 3 YOLO object classes
-msgid "5  bus"
-msgstr "5  公交车"
+msgid "6  bus"
+msgstr "6  公交车"
 
 #. Sentry 3 YOLO object classes
-msgid "6  train"
-msgstr "6  火车"
+msgid "7  train"
+msgstr "7  火车"
 
 #. Sentry 3 YOLO object classes
-msgid "7  truck"
-msgstr "7  卡车"
+msgid "8  truck"
+msgstr "8  卡车"
 
 #. Sentry 3 YOLO object classes
-msgid "8  boat"
-msgstr "8  船"
+msgid "9  boat"
+msgstr "9  船"
 
 #. Sentry 3 YOLO object classes
-msgid "9  traffic light"
-msgstr "9  信号灯"
+msgid "10 traffic light"
+msgstr "10 信号灯"
 
 #. Sentry 3 YOLO object classes
-msgid "10 fire hydrant"
-msgstr "10 消防栓"
+msgid "11 fire hydrant"
+msgstr "11 消防栓"
 
 #. Sentry 3 YOLO object classes
-msgid "11 stop sign"
-msgstr "11 停车标志"
+msgid "12 stop sign"
+msgstr "12 停车标志"
 
 #. Sentry 3 YOLO object classes
-msgid "12 parking meter"
-msgstr "12 计费器"
+msgid "13 parking meter"
+msgstr "13 计费器"
 
 #. Sentry 3 YOLO object classes
-msgid "13 bench"
-msgstr "13 长椅"
+msgid "14 bench"
+msgstr "14 长椅"
 
 #. Sentry 3 YOLO object classes
-msgid "14 bird"
-msgstr "14 鸟"
+msgid "15 bird"
+msgstr "15 鸟"
 
 #. Sentry 3 YOLO object classes
-msgid "15 cat"
-msgstr "15 猫"
+msgid "16 cat"
+msgstr "16 猫"
 
 #. Sentry 3 YOLO object classes
-msgid "16 dog"
-msgstr "16 狗"
+msgid "17 dog"
+msgstr "17 狗"
 
 #. Sentry 3 YOLO object classes
-msgid "17 horse"
-msgstr "17 马"
+msgid "18 horse"
+msgstr "18 马"
 
 #. Sentry 3 YOLO object classes
-msgid "18 sheep"
-msgstr "18 羊"
+msgid "19 sheep"
+msgstr "19 羊"
 
 #. Sentry 3 YOLO object classes
-msgid "19 cow"
-msgstr "19 牛"
+msgid "20 cow"
+msgstr "20 牛"
 
 #. Sentry 3 YOLO object classes
-msgid "20 elephant"
-msgstr "20 大象"
+msgid "21 elephant"
+msgstr "21 大象"
 
 #. Sentry 3 YOLO object classes
-msgid "21 bear"
-msgstr "21 熊"
+msgid "22 bear"
+msgstr "22 熊"
 
 #. Sentry 3 YOLO object classes
-msgid "22 zebra"
-msgstr "22 斑马"
+msgid "23 zebra"
+msgstr "23 斑马"
 
 #. Sentry 3 YOLO object classes
-msgid "23 giraffe"
-msgstr "23 长颈鹿"
+msgid "24 giraffe"
+msgstr "24 长颈鹿"
 
 #. Sentry 3 YOLO object classes
-msgid "24 backpack"
-msgstr "24 背包"
+msgid "25 backpack"
+msgstr "25 背包"
 
 #. Sentry 3 YOLO object classes
-msgid "25 umbrella"
-msgstr "25 雨伞"
+msgid "26 umbrella"
+msgstr "26 雨伞"
 
 #. Sentry 3 YOLO object classes
-msgid "26 handbag"
-msgstr "26 手提包"
+msgid "27 handbag"
+msgstr "27 手提包"
 
 #. Sentry 3 YOLO object classes
-msgid "27 tie"
-msgstr "27 领带"
+msgid "28 tie"
+msgstr "28 领带"
 
 #. Sentry 3 YOLO object classes
-msgid "28 suitcase"
-msgstr "28 行李箱"
+msgid "29 suitcase"
+msgstr "29 行李箱"
 
 #. Sentry 3 YOLO object classes
-msgid "29 frisbee"
-msgstr "29 飞盘"
+msgid "30 frisbee"
+msgstr "30 飞盘"
 
 #. Sentry 3 YOLO object classes
-msgid "30 skis"
-msgstr "30 双滑雪板"
+msgid "31 skis"
+msgstr "31 双滑雪板"
 
 #. Sentry 3 YOLO object classes
-msgid "31 snowboard"
-msgstr "31 单滑雪板"
+msgid "32 snowboard"
+msgstr "32 单滑雪板"
 
 #. Sentry 3 YOLO object classes
-msgid "32 sports ball"
-msgstr "32 运动球类"
+msgid "33 sports ball"
+msgstr "33 运动球类"
 
 #. Sentry 3 YOLO object classes
-msgid "33 kite"
-msgstr "33 风筝"
+msgid "34 kite"
+msgstr "34 风筝"
 
 #. Sentry 3 YOLO object classes
-msgid "34 baseball bat"
-msgstr "34 棒球棒"
+msgid "35 baseball bat"
+msgstr "35 棒球棒"
 
 #. Sentry 3 YOLO object classes
-msgid "35 baseball glove"
-msgstr "35 棒球手套"
+msgid "36 baseball glove"
+msgstr "36 棒球手套"
 
 #. Sentry 3 YOLO object classes
-msgid "36 skateboard"
-msgstr "36 滑板"
+msgid "37 skateboard"
+msgstr "37 滑板"
 
 #. Sentry 3 YOLO object classes
-msgid "37 surfboard"
-msgstr "37 冲浪板"
+msgid "38 surfboard"
+msgstr "38 冲浪板"
 
 #. Sentry 3 YOLO object classes
-msgid "38 tennis racket"
-msgstr "38 网球拍"
+msgid "39 tennis racket"
+msgstr "39 网球拍"
 
 #. Sentry 3 YOLO object classes
-msgid "39 bottle"
-msgstr "39 瓶子"
+msgid "40 bottle"
+msgstr "40 瓶子"
 
 #. Sentry 3 YOLO object classes
-msgid "40 wine glass"
-msgstr "40 红酒杯"
+msgid "41 wine glass"
+msgstr "41 红酒杯"
 
 #. Sentry 3 YOLO object classes
-msgid "41 cup"
-msgstr "41 杯子"
+msgid "42 cup"
+msgstr "42 杯子"
 
 #. Sentry 3 YOLO object classes
-msgid "42 fork"
-msgstr "42 叉子"
+msgid "43 fork"
+msgstr "43 叉子"
 
 #. Sentry 3 YOLO object classes
-msgid "43 knife"
-msgstr "43 刀"
+msgid "44 knife"
+msgstr "44 刀"
 
 #. Sentry 3 YOLO object classes
-msgid "44 spoon"
-msgstr "44 勺子"
+msgid "45 spoon"
+msgstr "45 勺子"
 
 #. Sentry 3 YOLO object classes
-msgid "45 bowl"
-msgstr "45 碗"
+msgid "46 bowl"
+msgstr "46 碗"
 
 #. Sentry 3 YOLO object classes
-msgid "46 banana"
-msgstr "46 香蕉"
+msgid "47 banana"
+msgstr "47 香蕉"
 
 #. Sentry 3 YOLO object classes
-msgid "47 apple"
-msgstr "47 苹果"
+msgid "48 apple"
+msgstr "48 苹果"
 
 #. Sentry 3 YOLO object classes
-msgid "48 sandwich"
-msgstr "48 三明治"
+msgid "49 sandwich"
+msgstr "49 三明治"
 
 #. Sentry 3 YOLO object classes
-msgid "49 orange"
-msgstr "49 橙子"
+msgid "50 orange"
+msgstr "50 橙子"
 
 #. Sentry 3 YOLO object classes
-msgid "50 broccoli"
-msgstr "50 西兰花"
+msgid "51 broccoli"
+msgstr "51 西兰花"
 
 #. Sentry 3 YOLO object classes
-msgid "51 carrot"
-msgstr "51 胡萝卜"
+msgid "52 carrot"
+msgstr "52 胡萝卜"
 
 #. Sentry 3 YOLO object classes
-msgid "52 hot dog"
-msgstr "52 热狗"
+msgid "53 hot dog"
+msgstr "53 热狗"
 
 #. Sentry 3 YOLO object classes
-msgid "53 pizza"
-msgstr "53 披萨"
+msgid "54 pizza"
+msgstr "54 披萨"
 
 #. Sentry 3 YOLO object classes
-msgid "54 donut"
-msgstr "54 甜甜圈"
+msgid "55 donut"
+msgstr "55 甜甜圈"
 
 #. Sentry 3 YOLO object classes
-msgid "55 cake"
-msgstr "55 蛋糕"
+msgid "56 cake"
+msgstr "56 蛋糕"
 
 #. Sentry 3 YOLO object classes
-msgid "56 chair"
-msgstr "56 椅子"
+msgid "57 chair"
+msgstr "57 椅子"
 
 #. Sentry 3 YOLO object classes
-msgid "57 couch"
-msgstr "57 沙发"
+msgid "58 couch"
+msgstr "58 沙发"
 
 #. Sentry 3 YOLO object classes
-msgid "58 potted plant"
-msgstr "58 盆栽植物"
+msgid "59 potted plant"
+msgstr "59 盆栽植物"
 
 #. Sentry 3 YOLO object classes
-msgid "59 bed"
-msgstr "59 床"
+msgid "60 bed"
+msgstr "60 床"
 
 #. Sentry 3 YOLO object classes
-msgid "60 dining table"
-msgstr "60 餐桌"
+msgid "61 dining table"
+msgstr "61 餐桌"
 
 #. Sentry 3 YOLO object classes
-msgid "61 toilet"
-msgstr "61 马桶"
+msgid "62 toilet"
+msgstr "62 马桶"
 
 #. Sentry 3 YOLO object classes
-msgid "62 tv"
-msgstr "62 显示器"
+msgid "63 tv"
+msgstr "63 显示器"
 
 #. Sentry 3 YOLO object classes
-msgid "63 laptop"
-msgstr "63 便携电脑"
+msgid "64 laptop"
+msgstr "64 便携电脑"
 
 #. Sentry 3 YOLO object classes
-msgid "64 mouse"
-msgstr "64 鼠标"
+msgid "65 mouse"
+msgstr "65 鼠标"
 
 #. Sentry 3 YOLO object classes
-msgid "65 remote"
-msgstr "65 遥控器"
+msgid "66 remote"
+msgstr "66 遥控器"
 
 #. Sentry 3 YOLO object classes
-msgid "66 keyboard"
-msgstr "66 键盘"
+msgid "67 keyboard"
+msgstr "67 键盘"
 
 #. Sentry 3 YOLO object classes
-msgid "67 cell phone"
-msgstr "67 手机"
+msgid "68 cell phone"
+msgstr "68 手机"
 
 #. Sentry 3 YOLO object classes
-msgid "68 microwave"
-msgstr "68 微波炉"
+msgid "69 microwave"
+msgstr "69 微波炉"
 
 #. Sentry 3 YOLO object classes
-msgid "69 oven"
-msgstr "69 烤箱"
+msgid "70 oven"
+msgstr "70 烤箱"
 
 #. Sentry 3 YOLO object classes
-msgid "70 toaster"
-msgstr "70 烤面包机"
+msgid "71 toaster"
+msgstr "71 烤面包机"
 
 #. Sentry 3 YOLO object classes
-msgid "71 sink"
-msgstr "71 水槽"
+msgid "72 sink"
+msgstr "72 水槽"
 
 #. Sentry 3 YOLO object classes
-msgid "72 refrigerator"
-msgstr "72 冰箱"
+msgid "73 refrigerator"
+msgstr "73 冰箱"
 
 #. Sentry 3 YOLO object classes
-msgid "73 book"
-msgstr "73 书"
+msgid "74 book"
+msgstr "74 书"
 
 #. Sentry 3 YOLO object classes
-msgid "74 clock"
-msgstr "74 钟表"
+msgid "75 clock"
+msgstr "75 钟表"
 
 #. Sentry 3 YOLO object classes
-msgid "75 vase"
-msgstr "75 花瓶"
+msgid "76 vase"
+msgstr "76 花瓶"
 
 #. Sentry 3 YOLO object classes
-msgid "76 scissors"
-msgstr "76 剪刀"
+msgid "77 scissors"
+msgstr "77 剪刀"
 
 #. Sentry 3 YOLO object classes
-msgid "77 teddy bear"
-msgstr "77 泰迪熊"
+msgid "78 teddy bear"
+msgstr "78 泰迪熊"
 
 #. Sentry 3 YOLO object classes
-msgid "78 hair drier"
-msgstr "78 吹风机"
+msgid "79 hair drier"
+msgstr "79 吹风机"
 
 #. Sentry 3 YOLO object classes
-msgid "79 toothbrush"
-msgstr "79 牙刷"
+msgid "80 toothbrush"
+msgstr "80 牙刷"
 
 #. Sentry3 HandPose Preset menu choices
 msgid "One"


### PR DESCRIPTION
更新了Sentry3视觉传感器的配置文件，将`HandGesture`重命名为`HandPose`以提高命名一致性。 同时修正了YOLO物体识别类别编号，使其从1开始而非0，并相应更新了所有相关索引值。